### PR TITLE
Collect parts across `<template>` element boundaries

### DIFF
--- a/src/template-parts.js
+++ b/src/template-parts.js
@@ -130,6 +130,7 @@ export const parse = (element, parts=[]) => {
 
   for (node of element.childNodes) {
     if (node.nodeType === ELEMENT && !(node instanceof HTMLTemplateElement)) parse(node, parts)
+    else if (node.nodeType === ELEMENT && bareTemplateElement(node)) parse(node.content, parts)
     else {
       if (node.nodeType === ELEMENT || node.data.includes('{{')) {
         const setter = {parentNode: element, parts:[]}
@@ -196,3 +197,11 @@ tokenize = (text) => {
   return mem[text] = tokens
 }
 const mem = {}
+
+const bareTemplateElement = (node) => {
+  if (node instanceof HTMLTemplateElement) {
+    return !(node.hasAttribute('directive') || node.hasAttribute('type') || node.hasAttribute('expression'))
+  } else {
+    return false
+  }
+}

--- a/template-parts.js
+++ b/template-parts.js
@@ -63,7 +63,7 @@ const defaultProcessor = {
         else if (
           typeof value === 'function' &&
           part instanceof AttributeTemplatePart
-        ) part.element[part.attributeName] = value; 
+        ) part.element[part.attributeName] = value;
         else part.value = value;
       }
   }
@@ -173,6 +173,7 @@ const parse = (element, parts=[]) => {
 
   for (node of element.childNodes) {
     if (node.nodeType === ELEMENT && !(node instanceof HTMLTemplateElement)) parse(node, parts);
+    else if (node.nodeType === ELEMENT && bareTemplateElement(node)) parse(node.content, parts);
     else {
       if (node.nodeType === ELEMENT || node.data.includes('{{')) {
         const setter = {parentNode: element, parts:[]};
@@ -239,5 +240,13 @@ tokenize = (text) => {
   return mem[text] = tokens
 };
 const mem = {};
+
+const bareTemplateElement = (node) => {
+  if (node instanceof HTMLTemplateElement) {
+    return !(node.hasAttribute('directive') || node.hasAttribute('type') || node.hasAttribute('expression'))
+  } else {
+    return false
+  }
+};
 
 export { AttributeTemplatePart, InnerTemplatePart, NodeTemplatePart, TemplateInstance, TemplatePart, defaultProcessor, parse, tokenize };

--- a/test/test.js
+++ b/test/test.js
@@ -151,6 +151,35 @@ test('create: applies data to templated element nodes', () => {
   is(root.innerHTML, `<div>Hello world</div>`)
 })
 
+test('create: applies data to templated DocumentFragment nodes', () => {
+  // https://github.com/github/template-parts/pull/73
+
+  const template = document.createElement('template')
+  const fragment = Object.assign(document.createElement('template'), {
+    innerHTML: '<div>Hello world</div>',
+  })
+  const originalHTML = '{{x}}'
+  template.innerHTML = originalHTML
+  const instance = new TemplateInstance(template, {x: fragment.content})
+  is(template.innerHTML, originalHTML)
+
+  const root = document.createElement('div')
+  root.appendChild(instance)
+  is(root.innerHTML, '<div>Hello world</div>')
+})
+
+test('create: applies data to nested templated element nodes', () => {
+  // https://github.com/github/template-parts/pull/72
+
+  const root = document.createElement('div')
+  const template = Object.assign(document.createElement('template'), {
+    innerHTML: '<template><div>{{x}}</div></template>',
+  })
+  root.appendChild(new TemplateInstance(template, {x: 'Hello world'}))
+
+  is(root.innerHTML, '<template><div>Hello world</div></template>')
+})
+
 test('create: can render into partial text nodes', () => {
   const template = document.createElement('template')
   const originalHTML = `Hello {{x}}!`


### PR DESCRIPTION
Take, for example, a `<template>` that nests other `<template>` elements:

```html
<template>
  <template>
    <div>{{x}}</div>
  </template>
</template>

<script type="module">
  import { TemplateInstance } from "template-parts"

  const template = document.querySelector("template")
  const instance = new TemplateInstance(template, { x: "Hello world" })

  document.body.append(instance)
</script>
```

Prior to this change, the inner `<template>` element (and its child `<div>`) are unchanged and still render `{{x}}` as a text node.

This change aims to bring support for templating across `<template>` boundaries. To achieve this behavior, add explicit [HTMLTemplateElement][] handling to the tree walking. When handling a `<template>` element that does not have attributes that would flag it as an `InnerTemplatePart`, walk its content `DocumentFragment`, treating variables in the same as way as the outer `<template>` element.

Without this support, explicit iteration and replacement is necessary for each boundary:

```js
const values = { x: "Hello world" }
const template = document.querySelector("template")
const instance = new TemplateInstance(template, values)

for (const nestedTemplate of instance.querySelectorAll("template")) {
  nestedTemplate.content.replaceChildren(new TemplateInstance(nestedTemplate, values))
}
```

[HTMLTemplateElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement